### PR TITLE
Scope pnpm --filter to @mariusdale/assembler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,14 @@ jobs:
         run: pnpm test
 
       - name: Bundle CLI for distribution
-        run: pnpm --filter assembler run bundle
+        run: pnpm --filter @mariusdale/assembler run bundle
 
       - name: Publish to npm
         run: |
           if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
-            pnpm --filter assembler publish --no-git-checks --access public --tag beta
+            pnpm --filter @mariusdale/assembler publish --no-git-checks --access public --tag beta
           else
-            pnpm --filter assembler publish --no-git-checks --access public
+            pnpm --filter @mariusdale/assembler publish --no-git-checks --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "PATH=\"$PWD/bin:$PATH\" turbo run lint",
     "typecheck": "PATH=\"$PWD/bin:$PATH\" turbo run typecheck",
     "test": "PATH=\"$PWD/bin:$PATH\" turbo run test",
-    "bundle": "pnpm --filter assembler run bundle",
+    "bundle": "pnpm --filter @mariusdale/assembler run bundle",
     "release": "pnpm build && pnpm bundle"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

The publishable CLI was renamed from `assembler` to `@mariusdale/assembler`. Update the two `pnpm --filter` references that still pointed at the unscoped name:

- `.github/workflows/release.yml` — bundle + two publish commands
- `package.json` — root `bundle` script

Leaves `apps/cli/package.json` untouched since that rename is being applied separately on your machine.

## Test plan

- [ ] After merging, once `apps/cli/package.json` also says `"name": "@mariusdale/assembler"`, a tag push (`git tag v0.1.0 && git push origin v0.1.0`) should successfully run bundle + publish.
- [ ] Before first tag: confirm `NPM_TOKEN` secret exists in repo settings.
- [ ] Confirm `npm view @mariusdale/assembler` returns "not found" (name available).

https://claude.ai/code/session_01LAV1aYM7meeEF8SYSoaQSH