### PR TITLE
Add framework strategy registry

### DIFF
--- a/packages/core/src/planner/framework-strategy.ts
+++ b/packages/core/src/planner/framework-strategy.ts
@@ -1,0 +1,41 @@
+import type { ProjectFramework, ProjectScan } from '@assembler/types';
+
+import type { PlannerTaskSeed } from './types.js';
+import { nextjsStrategy } from './strategies/nextjs.js';
+
+export interface FrameworkStrategyContext {
+  projectScan: ProjectScan;
+  appSlug: string;
+  repoTaskId: string;
+  requiresProvider(name: string): boolean;
+}
+
+export interface FrameworkStrategy {
+  readonly framework: ProjectFramework;
+  matches(scan: ProjectScan): boolean;
+  plan(ctx: FrameworkStrategyContext): PlannerTaskSeed[];
+}
+
+export interface FrameworkRegistry {
+  register(strategy: FrameworkStrategy): void;
+  resolve(scan: ProjectScan): FrameworkStrategy | undefined;
+}
+
+export function createFrameworkRegistry(): FrameworkRegistry {
+  const strategies: FrameworkStrategy[] = [];
+
+  return {
+    register(strategy) {
+      strategies.push(strategy);
+    },
+    resolve(scan) {
+      return strategies.find((strategy) => strategy.matches(scan));
+    },
+  };
+}
+
+export function createDefaultFrameworkRegistry(): FrameworkRegistry {
+  const registry = createFrameworkRegistry();
+  registry.register(nextjsStrategy);
+  return registry;
+}

--- a/packages/core/src/planner/index.ts
+++ b/packages/core/src/planner/index.ts
@@ -1,3 +1,5 @@
 export * from './project-scanner.js';
 export * from './rule-engine.js';
+export * from './framework-strategy.js';
+export * from './strategies/nextjs.js';
 export * from './types.js';

--- a/packages/core/src/planner/rule-engine.ts
+++ b/packages/core/src/planner/rule-engine.ts
@@ -1,5 +1,6 @@
 import type { ProjectScan, RiskLevel, RunPlan, Task } from '@assembler/types';
 
+import { createDefaultFrameworkRegistry } from './framework-strategy.js';
 import type { CreateRunPlanOptions, PlannerTaskSeed } from './types.js';
 
 const DEFAULT_RETRY_POLICY = {
@@ -165,91 +166,18 @@ function createTaskSeedsFromProjectScan(
     );
   }
 
-  if (projectScan.framework === 'nextjs') {
-    const predeployDependencies = ['github-push-code'];
-    if (requiresProvider(projectScan, 'neon')) {
-      predeployDependencies.push('neon-capture-database-url');
-    }
-    if (requiresProvider(projectScan, 'stripe')) {
-      predeployDependencies.push('stripe-capture-keys');
-    }
-    if (requiresProvider(projectScan, 'clerk')) {
-      predeployDependencies.push('clerk-capture-keys');
-    }
-    if (requiresProvider(projectScan, 'sentry')) {
-      predeployDependencies.push('sentry-capture-dsn');
-    }
-    if (requiresProvider(projectScan, 'resend')) {
-      predeployDependencies.push('resend-capture-api-key');
-    }
-
-    seeds.push(
-      taskSeed(
-        'vercel-create-project',
-        'Create Vercel project',
-        'vercel',
-        'create-project',
-        [repoTaskId],
-        {
-          name: appSlug,
-          framework: 'nextjs',
-        },
-        'medium',
-        true,
-      ),
-    );
-    seeds.push(
-      taskSeed(
-        'vercel-link-repository',
-        'Link Vercel to GitHub repository',
-        'vercel',
-        'link-repository',
-        ['vercel-create-project', 'github-push-code'],
-        {
-          name: appSlug,
-          framework: 'nextjs',
-        },
-        'medium',
-        true,
-      ),
-    );
-    seeds.push(
-      taskSeed(
-        'vercel-sync-predeploy-env-vars',
-        'Sync environment variables to Vercel',
-        'vercel',
-        'sync-predeploy-env-vars',
-        ['vercel-link-repository', ...predeployDependencies],
-      ),
-    );
-    seeds.push(
-      taskSeed(
-        'vercel-deploy-preview',
-        'Deploy to Vercel preview',
-        'vercel',
-        'deploy-preview',
-        ['vercel-sync-predeploy-env-vars'],
-      ),
-    );
-    seeds.push(
-      taskSeed(
-        'vercel-wait-for-ready',
-        'Wait for Vercel deployment readiness',
-        'vercel',
-        'wait-for-ready',
-        ['vercel-deploy-preview'],
-      ),
-    );
-    seeds.push(
-      taskSeed(
-        'vercel-health-check',
-        'Verify deployment health',
-        'vercel',
-        'health-check',
-        ['vercel-wait-for-ready'],
-      ),
-    );
-  }
+  const frameworkRegistry = options.frameworkRegistry ?? createDefaultFrameworkRegistry();
+  const frameworkStrategy = frameworkRegistry.resolve(projectScan);
+  seeds.push(
+    ...(frameworkStrategy?.plan({
+      projectScan,
+      appSlug,
+      repoTaskId,
+      requiresProvider(name) {
+        return requiresProvider(projectScan, name);
+      },
+    }) ?? []),
+  );
 
   return seeds;
 }
@@ -364,10 +292,6 @@ function estimateProjectScanCostUsd(projectScan: ProjectScan): number {
   let total = 0;
 
   if (requiresProvider(projectScan, 'neon')) {
-    total += 0;
-  }
-
-  if (projectScan.framework === 'nextjs') {
     total += 0;
   }
 

--- a/packages/core/src/planner/strategies/nextjs.ts
+++ b/packages/core/src/planner/strategies/nextjs.ts
@@ -1,0 +1,108 @@
+import type { RiskLevel } from '@assembler/types';
+
+import type { FrameworkStrategy } from '../framework-strategy.js';
+import type { PlannerTaskSeed } from '../types.js';
+
+export const nextjsStrategy: FrameworkStrategy = {
+  framework: 'nextjs',
+  matches(scan) {
+    return scan.framework === 'nextjs';
+  },
+  plan(ctx) {
+    const predeployDependencies = ['github-push-code'];
+    if (ctx.requiresProvider('neon')) {
+      predeployDependencies.push('neon-capture-database-url');
+    }
+    if (ctx.requiresProvider('stripe')) {
+      predeployDependencies.push('stripe-capture-keys');
+    }
+    if (ctx.requiresProvider('clerk')) {
+      predeployDependencies.push('clerk-capture-keys');
+    }
+    if (ctx.requiresProvider('sentry')) {
+      predeployDependencies.push('sentry-capture-dsn');
+    }
+    if (ctx.requiresProvider('resend')) {
+      predeployDependencies.push('resend-capture-api-key');
+    }
+
+    return [
+      taskSeed(
+        'vercel-create-project',
+        'Create Vercel project',
+        'vercel',
+        'create-project',
+        [ctx.repoTaskId],
+        {
+          name: ctx.appSlug,
+          framework: 'nextjs',
+        },
+        'medium',
+        true,
+      ),
+      taskSeed(
+        'vercel-link-repository',
+        'Link Vercel to GitHub repository',
+        'vercel',
+        'link-repository',
+        ['vercel-create-project', 'github-push-code'],
+        {
+          name: ctx.appSlug,
+          framework: 'nextjs',
+        },
+        'medium',
+        true,
+      ),
+      taskSeed(
+        'vercel-sync-predeploy-env-vars',
+        'Sync environment variables to Vercel',
+        'vercel',
+        'sync-predeploy-env-vars',
+        ['vercel-link-repository', ...predeployDependencies],
+      ),
+      taskSeed(
+        'vercel-deploy-preview',
+        'Deploy to Vercel preview',
+        'vercel',
+        'deploy-preview',
+        ['vercel-sync-predeploy-env-vars'],
+      ),
+      taskSeed(
+        'vercel-wait-for-ready',
+        'Wait for Vercel deployment readiness',
+        'vercel',
+        'wait-for-ready',
+        ['vercel-deploy-preview'],
+      ),
+      taskSeed(
+        'vercel-health-check',
+        'Verify deployment health',
+        'vercel',
+        'health-check',
+        ['vercel-wait-for-ready'],
+      ),
+    ];
+  },
+};
+
+function taskSeed(
+  id: string,
+  name: string,
+  provider: string,
+  action: string,
+  dependsOn: string[] = [],
+  params: Record<string, unknown> = {},
+  risk: RiskLevel = 'low',
+  requiresApproval = false,
+): PlannerTaskSeed {
+  return {
+    id,
+    name,
+    provider,
+    action,
+    params,
+    dependsOn,
+    risk,
+    requiresApproval,
+  };
+}

--- a/packages/core/src/planner/types.ts
+++ b/packages/core/src/planner/types.ts
@@ -1,9 +1,12 @@
 import type { Task } from '@assembler/types';
 
+import type { FrameworkRegistry } from './framework-strategy.js';
+
 export interface CreateRunPlanOptions {
   now?: Date;
   idGenerator?: () => string;
   useExistingRepo?: boolean;
+  frameworkRegistry?: FrameworkRegistry;
 }
 
 export interface PlannerTaskSeed {

--- a/packages/core/tests/framework-strategy.test.ts
+++ b/packages/core/tests/framework-strategy.test.ts
@@ -1,0 +1,77 @@
+import type { ProjectScan } from '@assembler/types';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createDefaultFrameworkRegistry,
+  createFrameworkRegistry,
+  createRunPlanFromProjectScan,
+  nextjsStrategy,
+} from '../src/index.js';
+
+const baseProjectScan = {
+  name: 'strategy-app',
+  framework: 'unknown',
+  directory: '/tmp/strategy-app',
+  hasGitRemote: false,
+  detectedProviders: [],
+  requiredEnvVars: [],
+  packageJson: {
+    name: 'strategy-app',
+  },
+  lockfileCheck: {
+    packageManager: 'pnpm',
+    lockfileExists: true,
+    inSync: true,
+    missingFromLockfile: [],
+    extraInLockfile: [],
+  },
+} satisfies ProjectScan;
+
+describe('framework strategy registry', () => {
+  it('resolves the first matching registered strategy', () => {
+    const registry = createFrameworkRegistry();
+    registry.register({
+      framework: 'unknown',
+      matches: (scan) => scan.framework === 'unknown',
+      plan: () => [],
+    });
+
+    expect(registry.resolve(baseProjectScan)?.framework).toBe('unknown');
+    expect(registry.resolve({ ...baseProjectScan, framework: 'astro' })).toBeUndefined();
+  });
+
+  it('pre-registers the Next.js strategy in the default registry', () => {
+    const registry = createDefaultFrameworkRegistry();
+
+    expect(registry.resolve({ ...baseProjectScan, framework: 'nextjs' })).toBe(nextjsStrategy);
+  });
+
+  it('lets a custom registry contribute framework-specific tasks', () => {
+    const registry = createFrameworkRegistry();
+    registry.register({
+      framework: 'unknown',
+      matches: (scan) => scan.framework === 'unknown',
+      plan: ({ appSlug, repoTaskId }) => [
+        {
+          id: 'custom-framework-task',
+          name: 'Run custom framework task',
+          provider: 'custom',
+          action: 'run',
+          params: { appSlug },
+          dependsOn: [repoTaskId],
+        },
+      ],
+    });
+
+    const plan = createRunPlanFromProjectScan(baseProjectScan, { frameworkRegistry: registry });
+
+    expect(plan.tasks.map((task) => task.id)).toEqual([
+      'github-create-repo',
+      'github-push-code',
+      'custom-framework-task',
+    ]);
+    expect(plan.tasks.find((task) => task.id === 'custom-framework-task')?.params).toEqual({
+      appSlug: 'strategy-app',
+    });
+  });
+});

--- a/packages/core/tests/planner.test.ts
+++ b/packages/core/tests/planner.test.ts
@@ -65,6 +65,215 @@ const sampleProjectScan = {
 } satisfies ProjectScan;
 
 describe('scan-driven planner', () => {
+  it('keeps the Next.js plan stable through the default framework strategy', () => {
+    const runPlan = createRunPlanFromProjectScan(sampleProjectScan, {
+      now: new Date('2026-03-27T00:00:00.000Z'),
+      idGenerator: () => 'run_test',
+    });
+
+    expect(
+      runPlan.tasks.map((task) => ({
+        id: task.id,
+        provider: task.provider,
+        action: task.action,
+        params: task.params,
+        dependsOn: task.dependsOn,
+        risk: task.risk,
+        requiresApproval: task.requiresApproval,
+      })),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "action": "create-repo",
+          "dependsOn": [],
+          "id": "github-create-repo",
+          "params": {
+            "description": "Deploy menugen",
+            "name": "menugen",
+            "private": true,
+          },
+          "provider": "github",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "push-code",
+          "dependsOn": [
+            "github-create-repo",
+          ],
+          "id": "github-push-code",
+          "params": {
+            "directory": "/tmp/menugen",
+          },
+          "provider": "github",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "create-project",
+          "dependsOn": [
+            "github-create-repo",
+          ],
+          "id": "neon-create-project",
+          "params": {
+            "databaseName": "menugen",
+            "name": "menugen-db",
+          },
+          "provider": "neon",
+          "requiresApproval": true,
+          "risk": "medium",
+        },
+        {
+          "action": "create-database",
+          "dependsOn": [
+            "neon-create-project",
+          ],
+          "id": "neon-create-database",
+          "params": {
+            "databaseName": "menugen",
+          },
+          "provider": "neon",
+          "requiresApproval": true,
+          "risk": "medium",
+        },
+        {
+          "action": "capture-database-url",
+          "dependsOn": [
+            "neon-create-database",
+          ],
+          "id": "neon-capture-database-url",
+          "params": {},
+          "provider": "neon",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "capture-keys",
+          "dependsOn": [
+            "github-create-repo",
+          ],
+          "id": "stripe-capture-keys",
+          "params": {},
+          "provider": "stripe",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "capture-keys",
+          "dependsOn": [
+            "github-create-repo",
+          ],
+          "id": "clerk-capture-keys",
+          "params": {},
+          "provider": "clerk",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "capture-dsn",
+          "dependsOn": [
+            "github-create-repo",
+          ],
+          "id": "sentry-capture-dsn",
+          "params": {},
+          "provider": "sentry",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "capture-api-key",
+          "dependsOn": [
+            "github-create-repo",
+          ],
+          "id": "resend-capture-api-key",
+          "params": {},
+          "provider": "resend",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "create-project",
+          "dependsOn": [
+            "github-create-repo",
+          ],
+          "id": "vercel-create-project",
+          "params": {
+            "framework": "nextjs",
+            "name": "menugen",
+          },
+          "provider": "vercel",
+          "requiresApproval": true,
+          "risk": "medium",
+        },
+        {
+          "action": "link-repository",
+          "dependsOn": [
+            "vercel-create-project",
+            "github-push-code",
+          ],
+          "id": "vercel-link-repository",
+          "params": {
+            "framework": "nextjs",
+            "name": "menugen",
+          },
+          "provider": "vercel",
+          "requiresApproval": true,
+          "risk": "medium",
+        },
+        {
+          "action": "sync-predeploy-env-vars",
+          "dependsOn": [
+            "vercel-link-repository",
+            "github-push-code",
+            "neon-capture-database-url",
+            "stripe-capture-keys",
+            "clerk-capture-keys",
+            "sentry-capture-dsn",
+            "resend-capture-api-key",
+          ],
+          "id": "vercel-sync-predeploy-env-vars",
+          "params": {},
+          "provider": "vercel",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "deploy-preview",
+          "dependsOn": [
+            "vercel-sync-predeploy-env-vars",
+          ],
+          "id": "vercel-deploy-preview",
+          "params": {},
+          "provider": "vercel",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "wait-for-ready",
+          "dependsOn": [
+            "vercel-deploy-preview",
+          ],
+          "id": "vercel-wait-for-ready",
+          "params": {},
+          "provider": "vercel",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+        {
+          "action": "health-check",
+          "dependsOn": [
+            "vercel-wait-for-ready",
+          ],
+          "id": "vercel-health-check",
+          "params": {},
+          "provider": "vercel",
+          "requiresApproval": false,
+          "risk": "low",
+        },
+      ]
+    `);
+  });
+
   it('generates a draft RunPlan in dependency order', () => {
     const runPlan = createRunPlanFromProjectScan(sampleProjectScan, {
       now: new Date('2026-03-27T00:00:00.000Z'),


### PR DESCRIPTION
## Summary

- Add the FrameworkStrategy and FrameworkRegistry contracts plus a default registry with the Next.js strategy pre-registered.
- Move the existing Next.js/Vercel planning slice out of rule-engine.ts into packages/core/src/planner/strategies/nextjs.ts.
- Let createRunPlanFromProjectScan use the default registry or an injected registry for tests/future frameworks.
- Add registry tests and a Next.js plan snapshot to prove the current task plan stays stable.

Closes #3

## Validation

- pnpm --filter @assembler/core run typecheck
- pnpm --filter @assembler/core run lint
- pnpm --filter @assembler/core run test
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build