### PR TITLE
[codex] Add deployment target abstraction

### DIFF
--- a/packages/core/src/planner/deployment-target-registry.ts
+++ b/packages/core/src/planner/deployment-target-registry.ts
@@ -1,0 +1,33 @@
+import type { DeployIntent, DeploymentTarget, DeploymentTargetRegistry } from '@assembler/types';
+
+import { vercelDeploymentTarget } from './targets/vercel.js';
+
+export function createDeploymentTargetRegistry(
+  initialTargets: DeploymentTarget[] = [],
+): DeploymentTargetRegistry {
+  const targets: DeploymentTarget[] = [];
+
+  for (const target of initialTargets) {
+    targets.push(target);
+  }
+
+  return {
+    register(target) {
+      targets.push(target);
+    },
+    selectFor(intent: DeployIntent, preference?: string) {
+      if (preference) {
+        const preferredTarget = targets.find(
+          (target) => target.name === preference || target.providerName === preference,
+        );
+        return preferredTarget?.supports(intent) ? preferredTarget : undefined;
+      }
+
+      return targets.find((target) => target.supports(intent));
+    },
+  };
+}
+
+export function createDefaultDeploymentTargetRegistry(): DeploymentTargetRegistry {
+  return createDeploymentTargetRegistry([vercelDeploymentTarget]);
+}

--- a/packages/core/src/planner/framework-strategy.ts
+++ b/packages/core/src/planner/framework-strategy.ts
@@ -1,13 +1,16 @@
-import type { ProjectFramework, ProjectScan } from '@assembler/types';
+import type {
+  DeploymentTargetPlanContext,
+  DeploymentTargetRegistry,
+  ProjectFramework,
+  ProjectScan,
+} from '@assembler/types';
 
 import type { PlannerTaskSeed } from './types.js';
 import { nextjsStrategy } from './strategies/nextjs.js';
 
-export interface FrameworkStrategyContext {
-  projectScan: ProjectScan;
-  appSlug: string;
-  repoTaskId: string;
-  requiresProvider(name: string): boolean;
+export interface FrameworkStrategyContext extends DeploymentTargetPlanContext {
+  deploymentTargets: DeploymentTargetRegistry;
+  deploymentTargetPreference?: string;
 }
 
 export interface FrameworkStrategy {

--- a/packages/core/src/planner/index.ts
+++ b/packages/core/src/planner/index.ts
@@ -1,5 +1,7 @@
 export * from './project-scanner.js';
 export * from './rule-engine.js';
+export * from './deployment-target-registry.js';
 export * from './framework-strategy.js';
 export * from './strategies/nextjs.js';
+export * from './targets/vercel.js';
 export * from './types.js';

--- a/packages/core/src/planner/rule-engine.ts
+++ b/packages/core/src/planner/rule-engine.ts
@@ -1,5 +1,6 @@
 import type { ProjectScan, RiskLevel, RunPlan, Task } from '@assembler/types';
 
+import { createDefaultDeploymentTargetRegistry } from './deployment-target-registry.js';
 import { createDefaultFrameworkRegistry } from './framework-strategy.js';
 import type { CreateRunPlanOptions, PlannerTaskSeed } from './types.js';
 
@@ -167,12 +168,18 @@ function createTaskSeedsFromProjectScan(
   }
 
   const frameworkRegistry = options.frameworkRegistry ?? createDefaultFrameworkRegistry();
+  const deploymentTargets =
+    options.deploymentTargetRegistry ?? createDefaultDeploymentTargetRegistry();
   const frameworkStrategy = frameworkRegistry.resolve(projectScan);
   seeds.push(
     ...(frameworkStrategy?.plan({
       projectScan,
       appSlug,
       repoTaskId,
+      deploymentTargets,
+      ...(options.deploymentTargetPreference
+        ? { deploymentTargetPreference: options.deploymentTargetPreference }
+        : {}),
       requiresProvider(name) {
         return requiresProvider(projectScan, name);
       },

--- a/packages/core/src/planner/strategies/nextjs.ts
+++ b/packages/core/src/planner/strategies/nextjs.ts
@@ -1,7 +1,6 @@
-import type { RiskLevel } from '@assembler/types';
+import type { DeployIntent } from '@assembler/types';
 
 import type { FrameworkStrategy } from '../framework-strategy.js';
-import type { PlannerTaskSeed } from '../types.js';
 
 export const nextjsStrategy: FrameworkStrategy = {
   framework: 'nextjs',
@@ -9,100 +8,17 @@ export const nextjsStrategy: FrameworkStrategy = {
     return scan.framework === 'nextjs';
   },
   plan(ctx) {
-    const predeployDependencies = ['github-push-code'];
-    if (ctx.requiresProvider('neon')) {
-      predeployDependencies.push('neon-capture-database-url');
-    }
-    if (ctx.requiresProvider('stripe')) {
-      predeployDependencies.push('stripe-capture-keys');
-    }
-    if (ctx.requiresProvider('clerk')) {
-      predeployDependencies.push('clerk-capture-keys');
-    }
-    if (ctx.requiresProvider('sentry')) {
-      predeployDependencies.push('sentry-capture-dsn');
-    }
-    if (ctx.requiresProvider('resend')) {
-      predeployDependencies.push('resend-capture-api-key');
+    const intent: DeployIntent = {
+      artifact: 'ssr-node',
+      framework: ctx.projectScan.framework,
+      envVarKeys: ctx.projectScan.requiredEnvVars.map((envVar) => envVar.name),
+    };
+    const target = ctx.deploymentTargets.selectFor(intent, ctx.deploymentTargetPreference);
+
+    if (!target) {
+      throw new Error(`No deployment target supports ${intent.framework} ${intent.artifact} apps.`);
     }
 
-    return [
-      taskSeed(
-        'vercel-create-project',
-        'Create Vercel project',
-        'vercel',
-        'create-project',
-        [ctx.repoTaskId],
-        {
-          name: ctx.appSlug,
-          framework: 'nextjs',
-        },
-        'medium',
-        true,
-      ),
-      taskSeed(
-        'vercel-link-repository',
-        'Link Vercel to GitHub repository',
-        'vercel',
-        'link-repository',
-        ['vercel-create-project', 'github-push-code'],
-        {
-          name: ctx.appSlug,
-          framework: 'nextjs',
-        },
-        'medium',
-        true,
-      ),
-      taskSeed(
-        'vercel-sync-predeploy-env-vars',
-        'Sync environment variables to Vercel',
-        'vercel',
-        'sync-predeploy-env-vars',
-        ['vercel-link-repository', ...predeployDependencies],
-      ),
-      taskSeed(
-        'vercel-deploy-preview',
-        'Deploy to Vercel preview',
-        'vercel',
-        'deploy-preview',
-        ['vercel-sync-predeploy-env-vars'],
-      ),
-      taskSeed(
-        'vercel-wait-for-ready',
-        'Wait for Vercel deployment readiness',
-        'vercel',
-        'wait-for-ready',
-        ['vercel-deploy-preview'],
-      ),
-      taskSeed(
-        'vercel-health-check',
-        'Verify deployment health',
-        'vercel',
-        'health-check',
-        ['vercel-wait-for-ready'],
-      ),
-    ];
+    return target.plan(intent, ctx);
   },
 };
-
-function taskSeed(
-  id: string,
-  name: string,
-  provider: string,
-  action: string,
-  dependsOn: string[] = [],
-  params: Record<string, unknown> = {},
-  risk: RiskLevel = 'low',
-  requiresApproval = false,
-): PlannerTaskSeed {
-  return {
-    id,
-    name,
-    provider,
-    action,
-    params,
-    dependsOn,
-    risk,
-    requiresApproval,
-  };
-}

--- a/packages/core/src/planner/targets/vercel.ts
+++ b/packages/core/src/planner/targets/vercel.ts
@@ -1,0 +1,117 @@
+import type {
+  DeployIntent,
+  DeploymentTarget,
+  DeploymentTaskSeed,
+  RiskLevel,
+} from '@assembler/types';
+
+export const vercelDeploymentTarget: DeploymentTarget = {
+  name: 'vercel',
+  providerName: 'vercel',
+  supports(intent: DeployIntent): boolean {
+    return intent.framework !== 'unknown' && intent.artifact !== 'docker';
+  },
+  plan(intent, ctx) {
+    const predeployDependencies = ['github-push-code'];
+    if (ctx.requiresProvider('neon')) {
+      predeployDependencies.push('neon-capture-database-url');
+    }
+    if (ctx.requiresProvider('stripe')) {
+      predeployDependencies.push('stripe-capture-keys');
+    }
+    if (ctx.requiresProvider('clerk')) {
+      predeployDependencies.push('clerk-capture-keys');
+    }
+    if (ctx.requiresProvider('sentry')) {
+      predeployDependencies.push('sentry-capture-dsn');
+    }
+    if (ctx.requiresProvider('resend')) {
+      predeployDependencies.push('resend-capture-api-key');
+    }
+
+    const projectParams = vercelProjectParams(intent, ctx.appSlug);
+
+    return [
+      taskSeed(
+        'vercel-create-project',
+        'Create Vercel project',
+        'vercel',
+        'create-project',
+        [ctx.repoTaskId],
+        projectParams,
+        'medium',
+        true,
+      ),
+      taskSeed(
+        'vercel-link-repository',
+        'Link Vercel to GitHub repository',
+        'vercel',
+        'link-repository',
+        ['vercel-create-project', 'github-push-code'],
+        projectParams,
+        'medium',
+        true,
+      ),
+      taskSeed(
+        'vercel-sync-predeploy-env-vars',
+        'Sync environment variables to Vercel',
+        'vercel',
+        'sync-predeploy-env-vars',
+        ['vercel-link-repository', ...predeployDependencies],
+      ),
+      taskSeed(
+        'vercel-deploy-preview',
+        'Deploy to Vercel preview',
+        'vercel',
+        'deploy-preview',
+        ['vercel-sync-predeploy-env-vars'],
+      ),
+      taskSeed(
+        'vercel-wait-for-ready',
+        'Wait for Vercel deployment readiness',
+        'vercel',
+        'wait-for-ready',
+        ['vercel-deploy-preview'],
+      ),
+      taskSeed(
+        'vercel-health-check',
+        'Verify deployment health',
+        'vercel',
+        'health-check',
+        ['vercel-wait-for-ready'],
+      ),
+    ];
+  },
+};
+
+function vercelProjectParams(intent: DeployIntent, name: string): Record<string, unknown> {
+  return {
+    name,
+    framework: intent.framework,
+    ...(intent.buildCommand ? { buildCommand: intent.buildCommand } : {}),
+    ...(intent.outputDirectory ? { outputDirectory: intent.outputDirectory } : {}),
+    ...(intent.nodeVersion ? { nodeVersion: intent.nodeVersion } : {}),
+  };
+}
+
+function taskSeed(
+  id: string,
+  name: string,
+  provider: string,
+  action: string,
+  dependsOn: string[] = [],
+  params: Record<string, unknown> = {},
+  risk: RiskLevel = 'low',
+  requiresApproval = false,
+): DeploymentTaskSeed {
+  return {
+    id,
+    name,
+    provider,
+    action,
+    params,
+    dependsOn,
+    risk,
+    requiresApproval,
+  };
+}

--- a/packages/core/src/planner/types.ts
+++ b/packages/core/src/planner/types.ts
@@ -1,4 +1,4 @@
-import type { Task } from '@assembler/types';
+import type { DeploymentTargetRegistry, DeploymentTaskSeed } from '@assembler/types';
 
 import type { FrameworkRegistry } from './framework-strategy.js';
 
@@ -7,18 +7,8 @@ export interface CreateRunPlanOptions {
   idGenerator?: () => string;
   useExistingRepo?: boolean;
   frameworkRegistry?: FrameworkRegistry;
+  deploymentTargetRegistry?: DeploymentTargetRegistry;
+  deploymentTargetPreference?: string;
 }
 
-export interface PlannerTaskSeed {
-  id: string;
-  name: string;
-  provider: string;
-  action: string;
-  params?: Record<string, unknown>;
-  dependsOn?: string[];
-  outputs?: Record<string, unknown>;
-  risk?: Task['risk'];
-  requiresApproval?: boolean;
-  retryPolicy?: Task['retryPolicy'];
-  timeoutMs?: number;
-}
+export type PlannerTaskSeed = DeploymentTaskSeed;

--- a/packages/core/tests/deployment-target.test.ts
+++ b/packages/core/tests/deployment-target.test.ts
@@ -1,0 +1,120 @@
+import type { DeployIntent, DeploymentTarget } from '@assembler/types';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createDefaultDeploymentTargetRegistry,
+  createDeploymentTargetRegistry,
+  createRunPlanFromProjectScan,
+} from '../src/index.js';
+
+const nextjsIntent: DeployIntent = {
+  artifact: 'ssr-node',
+  framework: 'nextjs',
+  envVarKeys: [],
+};
+
+const staticIntent: DeployIntent = {
+  artifact: 'static',
+  framework: 'astro',
+  outputDirectory: 'dist',
+  envVarKeys: [],
+};
+
+const unsupportedIntent: DeployIntent = {
+  artifact: 'docker',
+  framework: 'node',
+  envVarKeys: [],
+};
+
+describe('deployment target registry', () => {
+  it('selects the first registered target that supports the deploy intent', () => {
+    const registry = createDeploymentTargetRegistry([
+      target('unsupported', false),
+      target('supported', true),
+    ]);
+
+    expect(registry.selectFor(nextjsIntent)?.name).toBe('supported');
+  });
+
+  it('uses an explicit target preference when it can satisfy the intent', () => {
+    const registry = createDeploymentTargetRegistry([
+      target('vercel', true),
+      target('cloudflare-pages', true),
+    ]);
+
+    expect(registry.selectFor(staticIntent, 'cloudflare-pages')?.name).toBe(
+      'cloudflare-pages',
+    );
+  });
+
+  it('does not silently fall back when an explicit preference cannot satisfy the intent', () => {
+    const registry = createDeploymentTargetRegistry([
+      target('vercel', true),
+      target('docker', false),
+    ]);
+
+    expect(registry.selectFor(nextjsIntent, 'docker')).toBeUndefined();
+  });
+
+  it('pre-registers Vercel in the default deployment target registry', () => {
+    const registry = createDefaultDeploymentTargetRegistry();
+
+    expect(registry.selectFor(nextjsIntent)?.name).toBe('vercel');
+    expect(registry.selectFor(unsupportedIntent)).toBeUndefined();
+  });
+
+  it('lets framework strategies delegate deploy planning to the preferred target', () => {
+    const registry = createDeploymentTargetRegistry([
+      target('vercel', true),
+      target('custom-static', true),
+    ]);
+
+    const plan = createRunPlanFromProjectScan(
+      {
+        name: 'deployment-target-app',
+        framework: 'nextjs',
+        directory: '/tmp/deployment-target-app',
+        hasGitRemote: false,
+        detectedProviders: [],
+        requiredEnvVars: [],
+        packageJson: {
+          name: 'deployment-target-app',
+        },
+        lockfileCheck: {
+          packageManager: 'pnpm',
+          lockfileExists: true,
+          inSync: true,
+          missingFromLockfile: [],
+          extraInLockfile: [],
+        },
+      },
+      {
+        deploymentTargetRegistry: registry,
+        deploymentTargetPreference: 'custom-static',
+      },
+    );
+
+    expect(plan.tasks.map((task) => task.id)).toContain('custom-static-deploy');
+  });
+});
+
+function target(name: string, supportsIntent: boolean): DeploymentTarget {
+  return {
+    name,
+    providerName: name,
+    supports: () => supportsIntent,
+    plan: (intent, ctx) => [
+      {
+        id: `${name}-deploy`,
+        name: `Deploy to ${name}`,
+        provider: name,
+        action: 'deploy',
+        params: {
+          artifact: intent.artifact,
+          framework: intent.framework,
+        },
+        dependsOn: [ctx.repoTaskId],
+      },
+    ],
+  };
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -7,7 +7,7 @@ import { neonProviderPack } from './neon/index.js';
 import { resendProviderPack } from './resend/index.js';
 import { sentryProviderPack } from './sentry/index.js';
 import { stripeProviderPack } from './stripe/index.js';
-import { vercelProviderPack } from './vercel/index.js';
+import { vercelDeploymentTarget, vercelProviderPack } from './vercel/index.js';
 
 export const plannedProviders = [
   'github',
@@ -45,6 +45,7 @@ export {
   resendProviderPack,
   sentryProviderPack,
   stripeProviderPack,
+  vercelDeploymentTarget,
   vercelProviderPack,
 };
 

--- a/packages/providers/src/vercel/index.ts
+++ b/packages/providers/src/vercel/index.ts
@@ -1,9 +1,13 @@
 import type {
   Credentials,
+  DeployIntent,
+  DeploymentTarget,
+  DeploymentTaskSeed,
   DiscoveryResult,
   ExecutionContext,
   PreflightResult,
   ProviderPack,
+  RiskLevel,
   RollbackResult,
   Task,
   TaskResult,
@@ -13,6 +17,85 @@ import type {
 
 import { HttpError } from '../shared/http.js';
 import { VercelClient } from './client.js';
+
+export const vercelDeploymentTarget: DeploymentTarget = {
+  name: 'vercel',
+  providerName: 'vercel',
+  supports(intent: DeployIntent): boolean {
+    return intent.framework !== 'unknown' && intent.artifact !== 'docker';
+  },
+  plan(intent, ctx) {
+    const predeployDependencies = ['github-push-code'];
+    if (ctx.requiresProvider('neon')) {
+      predeployDependencies.push('neon-capture-database-url');
+    }
+    if (ctx.requiresProvider('stripe')) {
+      predeployDependencies.push('stripe-capture-keys');
+    }
+    if (ctx.requiresProvider('clerk')) {
+      predeployDependencies.push('clerk-capture-keys');
+    }
+    if (ctx.requiresProvider('sentry')) {
+      predeployDependencies.push('sentry-capture-dsn');
+    }
+    if (ctx.requiresProvider('resend')) {
+      predeployDependencies.push('resend-capture-api-key');
+    }
+
+    const projectParams = vercelProjectParams(intent, ctx.appSlug);
+
+    return [
+      deploymentTaskSeed(
+        'vercel-create-project',
+        'Create Vercel project',
+        'vercel',
+        'create-project',
+        [ctx.repoTaskId],
+        projectParams,
+        'medium',
+        true,
+      ),
+      deploymentTaskSeed(
+        'vercel-link-repository',
+        'Link Vercel to GitHub repository',
+        'vercel',
+        'link-repository',
+        ['vercel-create-project', 'github-push-code'],
+        projectParams,
+        'medium',
+        true,
+      ),
+      deploymentTaskSeed(
+        'vercel-sync-predeploy-env-vars',
+        'Sync environment variables to Vercel',
+        'vercel',
+        'sync-predeploy-env-vars',
+        ['vercel-link-repository', ...predeployDependencies],
+      ),
+      deploymentTaskSeed(
+        'vercel-deploy-preview',
+        'Deploy to Vercel preview',
+        'vercel',
+        'deploy-preview',
+        ['vercel-sync-predeploy-env-vars'],
+      ),
+      deploymentTaskSeed(
+        'vercel-wait-for-ready',
+        'Wait for Vercel deployment readiness',
+        'vercel',
+        'wait-for-ready',
+        ['vercel-deploy-preview'],
+      ),
+      deploymentTaskSeed(
+        'vercel-health-check',
+        'Verify deployment health',
+        'vercel',
+        'health-check',
+        ['vercel-wait-for-ready'],
+      ),
+    ];
+  },
+};
 
 export const vercelProviderPack: ProviderPack = {
   name: 'vercel',
@@ -120,7 +203,7 @@ export const vercelProviderPack: ProviderPack = {
     switch (task.action) {
       case 'create-project': {
         const projectName = asOptionalString(task.params.name) ?? toSlug(getProjectName(ctx));
-        const framework = asOptionalString(task.params.framework) ?? 'nextjs';
+        const framework = asOptionalString(task.params.framework);
 
         // Idempotency: check if project already exists
         try {
@@ -147,7 +230,7 @@ export const vercelProviderPack: ProviderPack = {
 
         const project = await client.createProject({
           name: projectName,
-          framework,
+          ...(framework ? { framework } : {}),
         });
 
         return {
@@ -164,7 +247,7 @@ export const vercelProviderPack: ProviderPack = {
           asOptionalString(ctx.getOutput('vercel-create-project', 'projectName')) ??
           asOptionalString(task.params.name) ??
           toSlug(getProjectName(ctx));
-        const framework = asOptionalString(task.params.framework) ?? 'nextjs';
+        const framework = asOptionalString(task.params.framework);
         const repoFullName = asString(
           resolveRepoOutput(ctx, 'repoFullName'),
           'github repository repoFullName',
@@ -184,11 +267,11 @@ export const vercelProviderPack: ProviderPack = {
         const project = await createOrResolveLinkedProject(client, {
           projectId,
           projectName,
-          framework,
           repoFullName,
           repoId,
           ownerId,
           productionBranch,
+          ...(framework ? { framework } : {}),
         });
 
         return {
@@ -647,6 +730,38 @@ function collectEnvVars(
   return vars;
 }
 
+function vercelProjectParams(intent: DeployIntent, name: string): Record<string, unknown> {
+  return {
+    name,
+    framework: intent.framework,
+    ...(intent.buildCommand ? { buildCommand: intent.buildCommand } : {}),
+    ...(intent.outputDirectory ? { outputDirectory: intent.outputDirectory } : {}),
+    ...(intent.nodeVersion ? { nodeVersion: intent.nodeVersion } : {}),
+  };
+}
+
+function deploymentTaskSeed(
+  id: string,
+  name: string,
+  provider: string,
+  action: string,
+  dependsOn: string[] = [],
+  params: Record<string, unknown> = {},
+  risk: RiskLevel = 'low',
+  requiresApproval = false,
+): DeploymentTaskSeed {
+  return {
+    id,
+    name,
+    provider,
+    action,
+    params,
+    dependsOn,
+    risk,
+    requiresApproval,
+  };
+}
+
 function resolveRepoOutput(ctx: ExecutionContext, key: string): unknown {
   return (
     ctx.getOutput('github-use-existing-repo', key) ??
@@ -741,7 +856,7 @@ async function createOrResolveLinkedProject(
   input: {
     projectId: string;
     projectName: string;
-    framework: string;
+    framework?: string;
     repoFullName: string;
     repoId: string | number;
     ownerId: string | number;
@@ -777,7 +892,7 @@ async function createOrResolveLinkedProject(
 
   return client.createProject({
     name: input.projectName,
-    framework: input.framework,
+    ...(input.framework ? { framework: input.framework } : {}),
     gitRepository: {
       type: 'github',
       repo: input.repoFullName,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,7 @@
 export type ProjectFramework = 'nextjs' | 'remix' | 'astro' | 'node' | 'unknown';
 
+export type DeployArtifactKind = 'ssr-node' | 'ssr-edge' | 'static' | 'docker';
+
 export interface DetectedProvider {
   provider: string;
   confidence: 'high' | 'medium' | 'low';
@@ -35,6 +37,15 @@ export interface ProjectScan {
   lockfileCheck: LockfileCheck;
 }
 
+export interface DeployIntent {
+  artifact: DeployArtifactKind;
+  framework: ProjectFramework;
+  buildCommand?: string;
+  outputDirectory?: string;
+  nodeVersion?: string;
+  envVarKeys: string[];
+}
+
 export type TaskStatus =
   | 'pending'
   | 'running'
@@ -50,6 +61,39 @@ export type RiskLevel = 'low' | 'medium' | 'high';
 export interface RetryPolicy {
   maxRetries: number;
   backoffMs: number;
+}
+
+export interface DeploymentTaskSeed {
+  id: string;
+  name: string;
+  provider: string;
+  action: string;
+  params?: Record<string, unknown>;
+  dependsOn?: string[];
+  outputs?: Record<string, unknown>;
+  risk?: RiskLevel;
+  requiresApproval?: boolean;
+  retryPolicy?: RetryPolicy;
+  timeoutMs?: number;
+}
+
+export interface DeploymentTargetPlanContext {
+  projectScan: ProjectScan;
+  appSlug: string;
+  repoTaskId: string;
+  requiresProvider(name: string): boolean;
+}
+
+export interface DeploymentTarget {
+  readonly name: string;
+  readonly providerName: string;
+  supports(intent: DeployIntent): boolean;
+  plan(intent: DeployIntent, ctx: DeploymentTargetPlanContext): DeploymentTaskSeed[];
+}
+
+export interface DeploymentTargetRegistry {
+  register(target: DeploymentTarget): void;
+  selectFor(intent: DeployIntent, preference?: string): DeploymentTarget | undefined;
 }
 
 export interface Task {


### PR DESCRIPTION
## Summary

- Add public deploy intent and deployment target registry types.
- Add a core deployment target registry with Vercel as the default target.
- Refactor the Next.js framework strategy to emit a generic deploy intent and delegate deploy task creation to the selected target.
- Export a Vercel deployment target adapter from the providers package and stop hardcoding the Next.js fallback inside the Vercel provider actions.
- Add registry and preference-selection coverage for deployment targets.

Closes #4.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm build`